### PR TITLE
Cli Adjustments

### DIFF
--- a/src/collapse.rs
+++ b/src/collapse.rs
@@ -3,10 +3,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 use crate::{
-    alignment::{Alignment, Strand, TandemRepeat},
-    chunks::ProximityGroup,
-    viz::{write_soda_html, AssemblySodaData},
-    Args,
+    alignment::{Alignment, Strand, TandemRepeat}, chunks::ProximityGroup, viz::{write_soda_html, AssemblySodaData}, AuroraArgs, AnnotationArgs
 };
 
 ///
@@ -28,7 +25,7 @@ pub struct Edge<'a> {
 
 pub fn assembly_graph<'a>(
     alignments: &[&'a Alignment],
-    args: &Args,
+    args: &AnnotationArgs,
 ) -> HashMap<&'a Alignment, Vec<Edge<'a>>> {
     // this relies on the alignments being sorted by target start
     alignments
@@ -414,7 +411,7 @@ impl<'a> AssemblyGroup<'a> {
         group: &ProximityGroup<'a>,
         confidence_avg_by_id: &HashMap<usize, f64>,
         confidence_by_id: &HashMap<usize, Vec<f64>>,
-        args: &Args,
+        args: &AuroraArgs,
     ) -> Self {
         let mut assemblies: Vec<Assembly> = vec![];
 
@@ -437,15 +434,17 @@ impl<'a> AssemblyGroup<'a> {
                     .into_iter()
                     .partition(|a| a.strand == Strand::Forward);
 
-                let mut fwd_graph = assembly_graph(&fwd_ali, args);
-                let mut rev_graph = assembly_graph(&rev_ali, args);
+                let mut fwd_graph = assembly_graph(&fwd_ali, &args.annotation_args);
+                let mut rev_graph = assembly_graph(&rev_ali, &args.annotation_args);
 
                 // if we are going to generate soda output
                 // for the assemblies, we need to store the
                 // links before we start messing with the graph
                 let mut fwd_links = vec![];
                 let mut rev_links = vec![];
-                if args.assembly_viz {
+                let vis_args = &args.visualization_args;
+
+                if vis_args.assembly_viz {
                     fwd_links = fwd_graph
                         .iter()
                         .flat_map(|(ali_from, edges)| {
@@ -493,7 +492,7 @@ impl<'a> AssemblyGroup<'a> {
                     rev_ali.len() == cnt
                 });
 
-                if args.assembly_viz {
+                if vis_args.assembly_viz {
                     if !fwd_ali.is_empty() {
                         let fwd_data = AssemblySodaData::new(
                             &fwd_assemblies,
@@ -502,7 +501,7 @@ impl<'a> AssemblyGroup<'a> {
                             confidence_avg_by_id,
                         );
 
-                        let fwd_path = args.viz_output_path.join(format!("{}-fwd.html", query_id));
+                        let fwd_path = vis_args.viz_output_path.join(format!("{}-fwd.html", query_id));
 
                         write_soda_html(
                             &fwd_data,
@@ -520,7 +519,7 @@ impl<'a> AssemblyGroup<'a> {
                             confidence_avg_by_id,
                         );
 
-                        let rev_path = args.viz_output_path.join(format!("{}-rev.html", query_id));
+                        let rev_path = vis_args.viz_output_path.join(format!("{}-rev.html", query_id));
 
                         write_soda_html(
                             &rev_data,

--- a/src/collapse.rs
+++ b/src/collapse.rs
@@ -3,13 +3,15 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 use crate::{
-    alignment::{Alignment, Strand, TandemRepeat}, chunks::ProximityGroup, viz::{write_soda_html, AssemblySodaData}, AuroraArgs, AnnotationArgs
+    alignment::{Alignment, Strand, TandemRepeat},
+    chunks::ProximityGroup,
+    viz::{write_soda_html, AssemblySodaData},
+    AnnotationArgs, AuroraArgs,
 };
 
-///
-///
-///
-///
+/// The direction of an `Edge` in terms of where
+/// `&Alignment` B (value) is in relation to `&Alignment` A (key)
+/// in the coordinate space of the chromosome
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum Direction {
     Left,
@@ -28,6 +30,7 @@ pub fn assembly_graph<'a>(
     args: &AnnotationArgs,
 ) -> HashMap<&'a Alignment, Vec<Edge<'a>>> {
     // this relies on the alignments being sorted by target start
+    // note: this assertion iter will only run in debug mode
     alignments
         .iter()
         .zip(alignments.iter().skip(1))
@@ -40,6 +43,8 @@ pub fn assembly_graph<'a>(
 
     alignments.iter().enumerate().for_each(|(a_idx, &a)| {
         alignments[a_idx + 1..].iter().for_each(|&b| {
+            // TODO: this is highly suspect, as this should never happen
+            //       ?????
             if a == b {
                 return;
             }
@@ -98,6 +103,8 @@ pub fn assembly<'a>(
     // sort the edge lists by edge weight
     graph
         .values_mut()
+        // TODO: this could use more graceful error handling
+        //       in the off chance that we get a NaN
         .for_each(|edge_list| edge_list.sort_by(|a, b| a.weight.partial_cmp(&b.weight).unwrap()));
 
     // sort the remaining alignments by their minimum edge weights
@@ -112,6 +119,8 @@ pub fn assembly<'a>(
             None => f64::INFINITY,
         };
 
+        // TODO: this could use more graceful error handling
+        //       in the off chance that we get a NaN
         x.partial_cmp(&y).unwrap()
     });
 
@@ -311,8 +320,8 @@ impl<'a> Assembly<'a> {
                     .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
                     .expect("mini dp matrix has an empty column");
 
-                let skip_loop_score = matrix[col_idx - 1][0] + (1e55f64).ln() / 30.0;
-                let query_to_skip_score = max_score_in_prev_col + (1e55f64).ln() / 2.0;
+                let skip_loop_score = matrix[col_idx - 1][0] + (1e-55f64).ln() / 30.0;
+                let query_to_skip_score = max_score_in_prev_col + (1e-55f64).ln() / 2.0;
 
                 if skip_loop_score > query_to_skip_score {
                     matrix[col_idx][0] += skip_loop_score;
@@ -501,7 +510,9 @@ impl<'a> AssemblyGroup<'a> {
                             confidence_avg_by_id,
                         );
 
-                        let fwd_path = vis_args.viz_output_path.join(format!("{}-fwd.html", query_id));
+                        let fwd_path = vis_args
+                            .viz_output_path
+                            .join(format!("{}-fwd.html", query_id));
 
                         write_soda_html(
                             &fwd_data,
@@ -519,7 +530,9 @@ impl<'a> AssemblyGroup<'a> {
                             confidence_avg_by_id,
                         );
 
-                        let rev_path = vis_args.viz_output_path.join(format!("{}-rev.html", query_id));
+                        let rev_path = vis_args
+                            .viz_output_path
+                            .join(format!("{}-rev.html", query_id));
 
                         write_soda_html(
                             &rev_data,

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,14 +89,14 @@ pub struct PerformanceArgs {
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct AnnotationArgs {
-    /// The probability of jumping between query models
+    /// The penalty of jumping between query models
     #[arg(
         short = 'J',
         long = "query-jump",
-        default_value = "1e-55",
+        default_value = "-126.64",
         value_name = "f"
     )]
-    pub query_jump_probability: f64,
+    pub query_jump_penalty: f64,
 
     /// The number of skip loops that are
     /// equal to a jump between query models

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,26 +53,25 @@ pub struct AuroraArgs {
     matrices: String,
 
     #[command(flatten)]
-    #[clap(next_help_heading="Annotation options")]
+    #[clap(next_help_heading = "Annotation options")]
     pub annotation_args: AnnotationArgs,
 
     #[command(flatten)]
-    #[clap(next_help_heading="Performance options")]
+    #[clap(next_help_heading = "Performance options")]
     pub performance_args: PerformanceArgs,
 
     #[command(flatten)]
-    #[clap(next_help_heading="File I/O options")]
+    #[clap(next_help_heading = "File I/O options")]
     pub io_args: IoArgs,
 
     #[command(flatten)]
-    #[clap(next_help_heading="Ultra options")]
+    #[clap(next_help_heading = "Ultra options")]
     pub ultra_args: UltraArgs,
 
     #[command(flatten)]
-    #[clap(next_help_heading="Visualization options")]
+    #[clap(next_help_heading = "Visualization options")]
     pub visualization_args: VisualizationArgs,
 }
-
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct PerformanceArgs {
@@ -85,7 +84,6 @@ pub struct PerformanceArgs {
     )]
     pub num_threads: usize,
 }
-
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct AnnotationArgs {
@@ -178,14 +176,12 @@ pub struct AnnotationArgs {
     pub skip_state_score_shift: f64,
 }
 
-
 #[derive(Args, Debug, Clone, Default)]
 pub struct IoArgs {
     /// Produce a file that describes the regions
     #[arg(long = "regions", value_name = "path")]
     pub regions_path: Option<PathBuf>,
 }
-
 
 #[derive(Args, Debug, Clone)]
 pub struct UltraArgs {
@@ -197,7 +193,6 @@ pub struct UltraArgs {
     #[arg(short = 'X', long = "exclude-isolated-tr")]
     pub exclude_isolated_tandem_repeats: bool,
 }
-
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct VisualizationArgs {
@@ -230,16 +225,11 @@ pub struct VisualizationArgs {
 
     #[clap(skip)]
     pub viz_reference_bed_index: HashMap<String, usize>,
-
 }
-
-//pub const SCORE_WINDOW_SIZE: usize = 31;
-//pub const BACKGROUND_WINDOW_SIZE: usize = 61;
-//pub const SKIP_STATE_SCORE: f64 = 10.0;
 
 fn main() -> Result<()> {
     let mut args = AuroraArgs::parse();
-    let vis_args = & mut args.visualization_args;
+    let vis_args = &mut args.visualization_args;
 
     if vis_args.viz {
         if let Ok(metadata) = fs::metadata(&vis_args.viz_output_path) {
@@ -302,17 +292,19 @@ fn main() -> Result<()> {
     let alignment_data =
         AlignmentData::from_caf_and_ultra_and_matrices(alignments_file, ultra_file, matrices_file)?;
 
-    let proximity_groups =
-        ProximityGroup::from_alignment_data(&alignment_data, args.annotation_args.target_join_distance)
-            .into_iter()
-            .filter(|g| {
-                if args.ultra_args.exclude_isolated_tandem_repeats {
-                    !g.alignments.is_empty()
-                } else {
-                    true
-                }
-            })
-            .collect_vec();
+    let proximity_groups = ProximityGroup::from_alignment_data(
+        &alignment_data,
+        args.annotation_args.target_join_distance,
+    )
+    .into_iter()
+    .filter(|g| {
+        if args.ultra_args.exclude_isolated_tandem_repeats {
+            !g.alignments.is_empty()
+        } else {
+            true
+        }
+    })
+    .collect_vec();
 
     if let Some(path) = &args.io_args.regions_path {
         let regions_file = File::create(path).unwrap();
@@ -336,7 +328,8 @@ fn main() -> Result<()> {
         let index_file = File::create(vis_args.viz_output_path.join("index.html")).unwrap();
         let mut index_writer = BufWriter::new(index_file);
 
-        vis_args.viz_constraints
+        vis_args
+            .viz_constraints
             .iter()
             .enumerate()
             .for_each(|(idx, c)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use alignment::AlignmentData;
 use chunks::ProximityGroup;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Args, Parser};
 use itertools::Itertools;
 use rayon::prelude::*;
 use viz::VizConstraint;
@@ -43,7 +43,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[derive(Debug, Parser, Clone)]
 #[command(name = "aurora")]
 #[command(about = "stuff")]
-pub struct Args {
+pub struct AuroraArgs {
     /// The path to CAF formatted alignments
     #[arg()]
     alignments: String,
@@ -52,6 +52,31 @@ pub struct Args {
     #[arg()]
     matrices: String,
 
+    #[command(flatten)]
+    #[clap(next_help_heading="Annotation options")]
+    pub annotation_args: AnnotationArgs,
+
+    #[command(flatten)]
+    #[clap(next_help_heading="Performance options")]
+    pub performance_args: PerformanceArgs,
+
+    #[command(flatten)]
+    #[clap(next_help_heading="File I/O options")]
+    pub io_args: IoArgs,
+
+    #[command(flatten)]
+    #[clap(next_help_heading="Ultra options")]
+    pub ultra_args: UltraArgs,
+
+    #[command(flatten)]
+    #[clap(next_help_heading="Visualization options")]
+    pub visualization_args: VisualizationArgs,
+}
+
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct PerformanceArgs {
+    /// Number of threads to use durring processing.
     #[arg(
         short = 't',
         long = "threads",
@@ -59,7 +84,11 @@ pub struct Args {
         value_name = "n"
     )]
     pub num_threads: usize,
+}
 
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct AnnotationArgs {
     /// The probability of jumping between query models
     #[arg(
         short = 'J',
@@ -121,10 +150,57 @@ pub struct Args {
     )]
     pub fudge_distance: usize,
 
+    /// The size of the window looked at to determine a single alignment score in nucleotides.
+    #[arg(
+        short = 'W',
+        long = "window-size",
+        default_value = "31",
+        value_name = "n"
+    )]
+    pub score_window_size: usize,
+
+    /// The size of the window looked at to determine alignment score of the background refrence score in nucleotides.
+    #[arg(
+        short = 'B',
+        long = "background-window-size",
+        default_value = "61",
+        value_name = "n"
+    )]
+    pub background_window_size: usize,
+
+    /// Apply an additional penalty to the skip state score.
+    #[arg(
+        short = 'S',
+        long = "skip-state-penalty",
+        default_value = "0.0",
+        value_name = "f"
+    )]
+    pub skip_state_score_shift: f64,
+}
+
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct IoArgs {
+    /// Produce a file that describes the regions
+    #[arg(long = "regions", value_name = "path")]
+    pub regions_path: Option<PathBuf>,
+}
+
+
+#[derive(Args, Debug, Clone)]
+pub struct UltraArgs {
     /// The path to ULTRA output
     #[arg(short = 'U', long = "ultra-file", value_name = "path")]
     pub ultra_file_path: Option<PathBuf>,
 
+    /// Don't adjudicate regions that are only made up of tandem repeats
+    #[arg(short = 'X', long = "exclude-isolated-tr")]
+    pub exclude_isolated_tandem_repeats: bool,
+}
+
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct VisualizationArgs {
     /// Produce visualization output for annotations
     #[arg(short = 'V', long = "viz")]
     pub viz: bool,
@@ -133,6 +209,10 @@ pub struct Args {
     /// visualization output will be written
     #[arg(long = "viz-out", default_value = "./viz", value_name = "path")]
     pub viz_output_path: PathBuf,
+
+    /// Produce visualization output for potential join "assemblies"
+    #[arg(long = "assembly-viz")]
+    pub assembly_viz: bool,
 
     /// A list of target names, starts, and ends
     /// that will constrain the visualization output
@@ -143,18 +223,6 @@ pub struct Args {
     )]
     pub viz_constraints: Vec<VizConstraint>,
 
-    /// Produce visualization output for potential join "assemblies"
-    #[arg(long = "assembly-viz")]
-    pub assembly_viz: bool,
-
-    /// Produce a file that describes the regions
-    #[arg(long = "regions", value_name = "path")]
-    pub regions_path: Option<PathBuf>,
-
-    /// Don't adjudicate regions that are only made up of tandem repeats
-    #[arg(short = 'X', long = "exclude-isolated-tr")]
-    pub exclude_isolated_tandem_repeats: bool,
-
     /// The path to the BED file that contains
     /// reference annotations for visualization
     #[arg(short = 'R', long = "viz-ref-bed", value_name = "path")]
@@ -162,30 +230,32 @@ pub struct Args {
 
     #[clap(skip)]
     pub viz_reference_bed_index: HashMap<String, usize>,
+
 }
 
-pub const SCORE_WINDOW_SIZE: usize = 31;
-pub const BACKGROUND_WINDOW_SIZE: usize = 61;
-pub const SKIP_STATE_SCORE: f64 = 10.0;
+//pub const SCORE_WINDOW_SIZE: usize = 31;
+//pub const BACKGROUND_WINDOW_SIZE: usize = 61;
+//pub const SKIP_STATE_SCORE: f64 = 10.0;
 
 fn main() -> Result<()> {
-    let mut args = Args::parse();
+    let mut args = AuroraArgs::parse();
+    let vis_args = & mut args.visualization_args;
 
-    if args.viz {
-        if let Ok(metadata) = fs::metadata(&args.viz_output_path) {
+    if vis_args.viz {
+        if let Ok(metadata) = fs::metadata(&vis_args.viz_output_path) {
             if metadata.is_dir() {
                 // TODO: real error
                 panic!(
                     "directory: {} already exists",
-                    args.viz_output_path.to_str().unwrap()
+                    vis_args.viz_output_path.to_str().unwrap()
                 )
             }
         }
 
-        create_dir_all(&args.viz_output_path)?;
-        args.viz_output_path = args.viz_output_path.canonicalize()?;
+        create_dir_all(&vis_args.viz_output_path)?;
+        vis_args.viz_output_path = vis_args.viz_output_path.canonicalize()?;
 
-        if let Some(path) = &args.viz_reference_bed_path {
+        if let Some(path) = &vis_args.viz_reference_bed_path {
             let file = File::open(path).expect("failed to open viz reference bed file");
             let reader = BufReader::new(file);
 
@@ -217,14 +287,14 @@ fn main() -> Result<()> {
                     prev_start = start;
                 });
 
-            args.viz_reference_bed_index = index;
+            vis_args.viz_reference_bed_index = index;
         }
     }
 
     let alignments_file = File::open(&args.alignments)?;
     let matrices_file = File::open(&args.matrices)?;
 
-    let ultra_file = match args.ultra_file_path {
+    let ultra_file = match args.ultra_args.ultra_file_path {
         Some(ref path) => Some(File::open(path)?),
         None => None,
     };
@@ -233,10 +303,10 @@ fn main() -> Result<()> {
         AlignmentData::from_caf_and_ultra_and_matrices(alignments_file, ultra_file, matrices_file)?;
 
     let proximity_groups =
-        ProximityGroup::from_alignment_data(&alignment_data, args.target_join_distance)
+        ProximityGroup::from_alignment_data(&alignment_data, args.annotation_args.target_join_distance)
             .into_iter()
             .filter(|g| {
-                if args.exclude_isolated_tandem_repeats {
+                if args.ultra_args.exclude_isolated_tandem_repeats {
                     !g.alignments.is_empty()
                 } else {
                     true
@@ -244,7 +314,7 @@ fn main() -> Result<()> {
             })
             .collect_vec();
 
-    if let Some(path) = &args.regions_path {
+    if let Some(path) = &args.io_args.regions_path {
         let regions_file = File::create(path).unwrap();
         let mut regions_writer = BufWriter::new(regions_file);
         proximity_groups.iter().enumerate().for_each(|(idx, g)| {
@@ -262,11 +332,11 @@ fn main() -> Result<()> {
         });
     }
 
-    if args.viz {
-        let index_file = File::create(args.viz_output_path.join("index.html")).unwrap();
+    if vis_args.viz {
+        let index_file = File::create(vis_args.viz_output_path.join("index.html")).unwrap();
         let mut index_writer = BufWriter::new(index_file);
 
-        args.viz_constraints
+        vis_args.viz_constraints
             .iter()
             .enumerate()
             .for_each(|(idx, c)| {
@@ -300,11 +370,11 @@ fn main() -> Result<()> {
 
     debug_assert!(validate_groups(
         &proximity_groups,
-        args.target_join_distance
+        args.annotation_args.target_join_distance
     ));
 
     rayon::ThreadPoolBuilder::new()
-        .num_threads(args.num_threads)
+        .num_threads(args.performance_args.num_threads)
         .build_global()
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,7 @@ pub struct AnnotationArgs {
     #[arg(
         short = 'J',
         long = "query-jump",
-        default_value = "-126.64",
+        default_value = "-127.0",
         value_name = "f"
     )]
     pub query_jump_penalty: f64,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,36 +3,28 @@ use std::fs;
 use itertools::Itertools;
 
 use crate::{
-    alignment::AlignmentData,
-    annotation::Annotation,
-    chunks::ProximityGroup,
-    collapse::AssemblyGroup,
-    confidence::confidence,
-    matrix::{Matrix, MatrixDef},
-    score_params::ScoreParams,
-    split::split_trace,
-    support::windowed_confidence,
-    viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment},
-    viz::AdjudicationSodaData,
-    windowed_scores::{build_target_seq_from_alignments, windowed_score, Background},
-    Args, BACKGROUND_WINDOW_SIZE, SCORE_WINDOW_SIZE,
+    alignment::AlignmentData, annotation::Annotation, chunks::ProximityGroup, collapse::AssemblyGroup, confidence::confidence, matrix::{Matrix, MatrixDef}, score_params::{approximnate_ideal_skip_state_score, ScoreParams}, split::split_trace, support::windowed_confidence, viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment}, viz::AdjudicationSodaData, windowed_scores::{build_target_seq_from_alignments, windowed_score, Background}, AuroraArgs
 };
 
 pub fn run_pipeline(
     proximity_group: &ProximityGroup,
     alignment_data: &AlignmentData,
     region_idx: usize,
-    mut args: Args,
+    mut args: AuroraArgs,
 ) {
-    if args.viz {
-        args.viz_output_path.push(format!("{}", region_idx));
-        fs::create_dir_all(&args.viz_output_path).unwrap();
+    let annot_args = &args.annotation_args;
+
+    if args.visualization_args.viz {
+        args.visualization_args.viz_output_path.push(format!("{}", region_idx));
+        fs::create_dir_all(&args.visualization_args.viz_output_path).unwrap();
     }
+
+    let vis_args = &args.visualization_args;
 
     let score_params = ScoreParams::new(
         proximity_group.alignments.len(),
-        args.query_jump_probability,
-        args.num_skip_loops_eq_to_jump,
+        annot_args.query_jump_probability,
+        annot_args.num_skip_loops_eq_to_jump,
     );
 
     let matrix_def = MatrixDef::from_proximity_group(proximity_group);
@@ -50,7 +42,13 @@ pub fn run_pipeline(
         &target_seq,
         target_start,
         target_length,
-        BACKGROUND_WINDOW_SIZE,
+        args.annotation_args.background_window_size,
+    );
+
+    let skip_state_score = approximnate_ideal_skip_state_score(
+        annot_args.num_skip_loops_eq_to_jump as f64,
+        annot_args.query_jump_probability,
+        annot_args.skip_state_score_shift
     );
 
     windowed_score(
@@ -59,7 +57,8 @@ pub fn run_pipeline(
         proximity_group.tandem_repeats,
         &alignment_data.substitution_matrices,
         &background,
-        SCORE_WINDOW_SIZE,
+        args.annotation_args.score_window_size,
+        skip_state_score
     )
     .unwrap();
 
@@ -68,9 +67,9 @@ pub fn run_pipeline(
     let (confidence_avg_by_id, confidence_by_id) = windowed_confidence(&mut confidence_matrix);
 
     // adjust the skip state to include skip-loop penalty
-    let skip_adjust = args
+    let skip_adjust = annot_args
         .query_jump_probability
-        .powf(1.0 / args.num_skip_loops_eq_to_jump as f64);
+        .powf(1.0 / annot_args.num_skip_loops_eq_to_jump as f64);
 
     (0..confidence_matrix.num_cols()).for_each(|col_idx| {
         confidence_matrix.set_skip(col_idx, confidence_matrix.get_skip(col_idx) * skip_adjust);
@@ -152,7 +151,7 @@ pub fn run_pipeline(
         // we should absolutely never end up increasing our column count
         debug_assert!(new_active_cols.len() <= active_cols.len());
 
-        if args.viz {
+        if vis_args.viz {
             soda_data.add(split_results);
         }
 
@@ -209,15 +208,15 @@ pub fn run_pipeline(
         })
         .collect_vec();
 
-    if args.viz {
+    if vis_args.viz {
         // TODO: this is kind of awkward
         soda_data.set_annotations(annotations.clone());
 
-        let out_path = args.viz_output_path.join("index.html");
+        let out_path = vis_args.viz_output_path.join("index.html");
         soda_data.write(out_path);
     }
 
-    if !args.viz_constraints.is_empty() {
+    if !vis_args.viz_constraints.is_empty() {
         let target_name = alignment_data
             .target_name_map
             .get(proximity_group.target_id)
@@ -226,7 +225,7 @@ pub fn run_pipeline(
         let target_start = proximity_group.target_start;
         let target_end = proximity_group.target_end;
 
-        let constraints = args
+        let constraints = vis_args
             .viz_constraints
             .iter()
             .filter(|c| c.target_name == target_name)
@@ -234,7 +233,7 @@ pub fn run_pipeline(
             .collect_vec();
 
         constraints.iter().for_each(|constraint| {
-            let out_path = args.viz_output_path.parent().unwrap().join(format!(
+            let out_path = vis_args.viz_output_path.parent().unwrap().join(format!(
                 "{}-{}-{}.html",
                 constraint.target_name, constraint.target_start, constraint.target_end
             ));

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,7 +3,7 @@ use std::fs;
 use itertools::Itertools;
 
 use crate::{
-    alignment::AlignmentData, annotation::Annotation, chunks::ProximityGroup, collapse::AssemblyGroup, confidence::confidence, matrix::{Matrix, MatrixDef}, score_params::{approximnate_ideal_skip_state_score, ScoreParams}, split::split_trace, support::windowed_confidence, viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment}, viz::AdjudicationSodaData, windowed_scores::{build_target_seq_from_alignments, windowed_score, Background}, AuroraArgs
+    alignment::AlignmentData, annotation::Annotation, chunks::ProximityGroup, collapse::AssemblyGroup, confidence::confidence, matrix::{Matrix, MatrixDef}, score_params::{approximate_ideal_skip_state_score, ScoreParams}, split::split_trace, support::windowed_confidence, viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment}, viz::AdjudicationSodaData, windowed_scores::{build_target_seq_from_alignments, windowed_score, Background}, AuroraArgs
 };
 
 pub fn run_pipeline(
@@ -45,7 +45,7 @@ pub fn run_pipeline(
         args.annotation_args.background_window_size,
     );
 
-    let skip_state_score = approximnate_ideal_skip_state_score(
+    let skip_state_score = approximate_ideal_skip_state_score(
         annot_args.num_skip_loops_eq_to_jump as f64,
         annot_args.query_jump_penalty,
         annot_args.skip_state_score_shift

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -3,7 +3,19 @@ use std::fs;
 use itertools::Itertools;
 
 use crate::{
-    alignment::AlignmentData, annotation::Annotation, chunks::ProximityGroup, collapse::AssemblyGroup, confidence::confidence, matrix::{Matrix, MatrixDef}, score_params::{approximate_ideal_skip_state_score, ScoreParams}, split::split_trace, support::windowed_confidence, viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment}, viz::AdjudicationSodaData, windowed_scores::{build_target_seq_from_alignments, windowed_score, Background}, AuroraArgs
+    alignment::AlignmentData,
+    annotation::Annotation,
+    chunks::ProximityGroup,
+    collapse::AssemblyGroup,
+    confidence::confidence,
+    matrix::{Matrix, MatrixDef},
+    score_params::{approximate_ideal_skip_state_score, ScoreParams},
+    split::split_trace,
+    support::windowed_confidence,
+    viterbi::{trace_segments, traceback, viterbi_collapsed, TraceSegment},
+    viz::AdjudicationSodaData,
+    windowed_scores::{build_target_seq_from_alignments, windowed_score, Background},
+    AuroraArgs,
 };
 
 pub fn run_pipeline(
@@ -15,7 +27,9 @@ pub fn run_pipeline(
     let annot_args = &args.annotation_args;
 
     if args.visualization_args.viz {
-        args.visualization_args.viz_output_path.push(format!("{}", region_idx));
+        args.visualization_args
+            .viz_output_path
+            .push(format!("{}", region_idx));
         fs::create_dir_all(&args.visualization_args.viz_output_path).unwrap();
     }
 
@@ -48,7 +62,7 @@ pub fn run_pipeline(
     let skip_state_score = approximate_ideal_skip_state_score(
         annot_args.num_skip_loops_eq_to_jump as f64,
         annot_args.query_jump_penalty,
-        annot_args.skip_state_score_shift
+        annot_args.skip_state_score_shift,
     );
 
     windowed_score(
@@ -58,7 +72,7 @@ pub fn run_pipeline(
         &alignment_data.substitution_matrices,
         &background,
         args.annotation_args.score_window_size,
-        skip_state_score
+        skip_state_score,
     )
     .unwrap();
 
@@ -68,7 +82,8 @@ pub fn run_pipeline(
 
     // adjust the skip state to include skip-loop penalty
     let skip_adjust = annot_args
-        .query_jump_penalty.exp()
+        .query_jump_penalty
+        .exp()
         .powf(1.0 / annot_args.num_skip_loops_eq_to_jump as f64);
 
     (0..confidence_matrix.num_cols()).for_each(|col_idx| {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -23,7 +23,7 @@ pub fn run_pipeline(
 
     let score_params = ScoreParams::new(
         proximity_group.alignments.len(),
-        annot_args.query_jump_probability,
+        annot_args.query_jump_penalty,
         annot_args.num_skip_loops_eq_to_jump,
     );
 
@@ -47,7 +47,7 @@ pub fn run_pipeline(
 
     let skip_state_score = approximnate_ideal_skip_state_score(
         annot_args.num_skip_loops_eq_to_jump as f64,
-        annot_args.query_jump_probability,
+        annot_args.query_jump_penalty,
         annot_args.skip_state_score_shift
     );
 
@@ -68,7 +68,7 @@ pub fn run_pipeline(
 
     // adjust the skip state to include skip-loop penalty
     let skip_adjust = annot_args
-        .query_jump_probability
+        .query_jump_penalty.exp()
         .powf(1.0 / annot_args.num_skip_loops_eq_to_jump as f64);
 
     (0..confidence_matrix.num_cols()).for_each(|col_idx| {

--- a/src/score_params.rs
+++ b/src/score_params.rs
@@ -9,6 +9,14 @@ pub struct ScoreParams {
     pub skip_loop_score: f64,
 }
 
+pub fn approximnate_ideal_skip_state_score(
+    num_skip_loops_match_jump: f64,
+    query_jump_penalty: f64,
+    penalty_shift: f64
+) -> f64 {
+    return penalty_shift - (1.0 / num_skip_loops_match_jump) * query_jump_penalty.log2();
+}
+
 impl ScoreParams {
     pub fn new(
         num_alignments: usize,

--- a/src/score_params.rs
+++ b/src/score_params.rs
@@ -9,21 +9,21 @@ pub struct ScoreParams {
     pub skip_loop_score: f64,
 }
 
-pub fn approximnate_ideal_skip_state_score(
+pub fn approximate_ideal_skip_state_score(
     num_skip_loops_match_jump: f64,
-    query_jump_penalty_nits: f64,
+    query_jump_penalty_nats: f64,
     penalty_shift: f64
 ) -> f64 {
-    return penalty_shift - ((1.0 / num_skip_loops_match_jump) * query_jump_penalty_nits);
+    return -(query_jump_penalty_nats/ num_skip_loops_match_jump) + penalty_shift;
 }
 
 impl ScoreParams {
     pub fn new(
         num_alignments: usize,
-        query_jump_penalty_nits: f64,
+        query_jump_penalty_nats: f64,
         num_skip_loops_eq_to_jump: usize,
     ) -> Self {
-        let query_jump_score = query_jump_penalty_nits - (num_alignments as f64).ln();
+        let query_jump_score = query_jump_penalty_nats - (num_alignments as f64).ln();
         // jumping to the skip state and then jumping back to a query sequence
         // should be the same cost as jumping between query sequences
         let query_to_skip_score = (query_jump_score / 2.0) 

--- a/src/score_params.rs
+++ b/src/score_params.rs
@@ -11,22 +11,19 @@ pub struct ScoreParams {
 
 pub fn approximnate_ideal_skip_state_score(
     num_skip_loops_match_jump: f64,
-    query_jump_penalty: f64,
+    query_jump_penalty_nits: f64,
     penalty_shift: f64
 ) -> f64 {
-    return penalty_shift - (1.0 / num_skip_loops_match_jump) * query_jump_penalty.log2();
+    return penalty_shift - ((1.0 / num_skip_loops_match_jump) * query_jump_penalty_nits);
 }
 
 impl ScoreParams {
     pub fn new(
         num_alignments: usize,
-        query_jump_probability: f64,
+        query_jump_penalty_nits: f64,
         num_skip_loops_eq_to_jump: usize,
     ) -> Self {
-        let query_jump_probability_per = query_jump_probability / num_alignments as f64;
-
-        let query_jump_score = query_jump_probability_per.ln();
-
+        let query_jump_score = query_jump_penalty_nits - (num_alignments as f64).ln();
         // jumping to the skip state and then jumping back to a query sequence
         // should be the same cost as jumping between query sequences
         let query_to_skip_score = (query_jump_score / 2.0) 

--- a/src/split.rs
+++ b/src/split.rs
@@ -6,7 +6,7 @@ use crate::{
     alignment::Alignment,
     collapse::{Assembly, AssemblyGroup},
     viterbi::TraceSegment,
-    Args,
+    AuroraArgs,
 };
 
 #[derive(Debug)]
@@ -50,8 +50,9 @@ pub fn split_trace(
     assembly_group: &AssemblyGroup,
     active_cols: &[usize],
     confidence_avg_by_id: &HashMap<usize, f64>,
-    args: &Args,
+    args: &AuroraArgs,
 ) -> SplitResults {
+    let annot_args = &args.annotation_args;
     // for competittion, we are only going to
     // consider the rows that are in the trace
     let rows_in_trace = trace_segments
@@ -120,8 +121,8 @@ pub fn split_trace(
             .for_each(|(idx_b, stuff_b)| {
                 // first check if B happens to be properly contained in a gap of A
                 let b_in_a = stuff_a.gap_matrix_ranges.iter().any(|gap| {
-                    stuff_b.col_start >= gap.col_start - args.fudge_distance
-                        && stuff_b.col_end <= gap.col_end + args.fudge_distance
+                    stuff_b.col_start >= gap.col_start - annot_args.fudge_distance
+                        && stuff_b.col_end <= gap.col_end + annot_args.fudge_distance
                 });
 
                 if b_in_a {
@@ -130,9 +131,9 @@ pub fn split_trace(
 
                 // now check if A happens to be properly contained in a gap of B
                 let a_in_b = stuff_b.gap_matrix_ranges.iter().any(|gap| {
-                    stuff_a.col_start + args.fudge_distance >= gap.col_start - args.fudge_distance
-                        && stuff_a.col_end - args.fudge_distance
-                            <= gap.col_end + args.fudge_distance
+                    stuff_a.col_start + annot_args.fudge_distance >= gap.col_start - annot_args.fudge_distance
+                        && stuff_a.col_end - annot_args.fudge_distance
+                            <= gap.col_end + annot_args.fudge_distance
                 });
 
                 if a_in_b {
@@ -142,8 +143,8 @@ pub fn split_trace(
                 // now check if any fragment of B is inside a gap in A
                 let conflict_a = stuff_a.gap_matrix_ranges.iter().any(|gap| {
                     stuff_b.alignment_matrix_ranges.iter().any(|frag| {
-                        frag.col_start < gap.col_end - args.fudge_distance
-                            && frag.col_end > gap.col_start + args.fudge_distance
+                        frag.col_start < gap.col_end - annot_args.fudge_distance
+                            && frag.col_end > gap.col_start + annot_args.fudge_distance
                     })
                 });
 
@@ -155,8 +156,8 @@ pub fn split_trace(
                 // now check if any fragment of A is inside a gap in B
                 let conflict_b = stuff_b.gap_matrix_ranges.iter().any(|gap| {
                     stuff_a.alignment_matrix_ranges.iter().any(|frag| {
-                        frag.col_start < gap.col_end - args.fudge_distance
-                            && frag.col_end > gap.col_start + args.fudge_distance
+                        frag.col_start < gap.col_end - annot_args.fudge_distance
+                            && frag.col_end > gap.col_start + annot_args.fudge_distance
                     })
                 });
 
@@ -238,13 +239,13 @@ pub fn split_trace(
             // if for ALL of the gaps in the assembly
             stuff.gap_matrix_ranges.iter().all(|assembly_gap| {
                 // if the gap is smaller than the fudge distance
-                if assembly_gap.col_end - assembly_gap.col_start <= args.fudge_distance {
+                if assembly_gap.col_end - assembly_gap.col_start <= annot_args.fudge_distance {
                     return true;
                 }
                 // or if the gap is contained in ANY inactive column range
                 inactive_col_ranges.iter().any(|range| {
-                    assembly_gap.col_start >= range.col_start.saturating_sub(args.fudge_distance)
-                        && assembly_gap.col_end <= range.col_end + args.fudge_distance
+                    assembly_gap.col_start >= range.col_start.saturating_sub(annot_args.fudge_distance)
+                        && assembly_gap.col_end <= range.col_end + annot_args.fudge_distance
                 })
             })
         });

--- a/src/substitution_matrix.rs
+++ b/src/substitution_matrix.rs
@@ -134,6 +134,8 @@ impl AlignmentScore for SubstitutionMatrix {
         if t < 4 && q < 4 {
             (self.core_ratios[t][q] / frequencies[t]).ln()
         } else {
+            // TODO: Why did jack do this?
+            // this may not be in the same base (bits instead of nats), and also might be scaled by the lambda.
             self.scores[t][q]
         }
     }

--- a/src/viz/mod.rs
+++ b/src/viz/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     matrix::Matrix,
     split::SplitResults,
     viterbi::TraceSegment,
-    Args,
+    AuroraArgs,
 };
 
 #[derive(Clone, Debug)]
@@ -122,7 +122,7 @@ pub struct AdjudicationSodaData<'a> {
     annotations: Vec<Annotation>,
     split_results: Vec<SplitResults>,
     maybe_constraint: Option<&'a VizConstraint>,
-    args: &'a Args,
+    args: &'a AuroraArgs,
 }
 
 impl<'a> AdjudicationSodaData<'a> {
@@ -134,7 +134,7 @@ impl<'a> AdjudicationSodaData<'a> {
         confidence_matrix: &'a Matrix<'a, f64>,
         alignment_data: &'a AlignmentData,
         target_seq: &'a [u8],
-        args: &'a Args,
+        args: &'a AuroraArgs,
     ) -> Self {
         Self {
             group,
@@ -266,8 +266,8 @@ impl<'a> AdjudicationSodaData<'a> {
             .get(self.group.target_id);
 
         if let (Some(path), Some(&offset)) = (
-            &self.args.viz_reference_bed_path,
-            self.args.viz_reference_bed_index.get(target_name),
+            &self.args.visualization_args.viz_reference_bed_path,
+            self.args.visualization_args.viz_reference_bed_index.get(target_name),
         ) {
             let file = File::open(path).expect("failed to open reference bed");
             let reader = BufReader::new(file);

--- a/src/windowed_scores.rs
+++ b/src/windowed_scores.rs
@@ -8,7 +8,6 @@ use crate::alphabet::{
 use crate::matrix::Matrix;
 use crate::substitution_matrix::{AlignmentScore, SubstitutionMatrix};
 use crate::util::VecMap;
-use crate::SKIP_STATE_SCORE;
 
 pub fn build_target_seq_from_alignments(
     alignments: &[Alignment],
@@ -292,12 +291,13 @@ pub fn windowed_score(
     substitution_matrices: &VecMap<SubstitutionMatrix>,
     background: &impl BackgroundFrequencies,
     window_size: usize,
+    skip_state_score: f64
 ) -> anyhow::Result<()> {
     let target_start = matrix.target_start();
 
     // set the skip score uniformly
     (0..matrix.num_cols()).for_each(|col_idx| {
-        matrix.set_skip(col_idx, SKIP_STATE_SCORE);
+        matrix.set_skip(col_idx, skip_state_score);
     });
 
     for (row_idx, ali, sub_matrix) in alignments
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(scores, correct);
 
         let correct = vec![-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0];
-        let scores = windowed_score_alignment(&a, &s, crate::SCORE_WINDOW_SIZE, &b)?;
+        let scores = windowed_score_alignment(&a, &s, 31, &b)?;
         assert_eq!(scores, correct);
 
         Ok(())


### PR DESCRIPTION
 - Add categories to the CLI
 - Add global constants as parameters to CLI with same default values (window sizes and skip state score)
 - Skip state initial score is now set based on the skip transition penalty as proposed by Travis.
 - All cli arguments that use to be probabilities are now in nats, as scores.
